### PR TITLE
Added a quieter indent-guide style

### DIFF
--- a/index.less
+++ b/index.less
@@ -69,3 +69,7 @@
   color: #CDCDCD;
   background-color: #CC99CC;
 }
+
+.indent-guide {
+  color:  #444444;
+}


### PR DESCRIPTION
The default indent-guide is white and is very distracting so now its much nicer
### Before

![screen shot 2015-01-09 at 14 57 59](https://cloud.githubusercontent.com/assets/99309/5681425/6a488eda-9810-11e4-87e0-c5d6a3fb1bf9.png)
### After

![screen shot 2015-01-09 at 15 00 10](https://cloud.githubusercontent.com/assets/99309/5681431/78fd44b6-9810-11e4-936c-57d48253aca2.png)
